### PR TITLE
add floor for ADC "off" threshhold

### DIFF
--- a/src/app_settings.h
+++ b/src/app_settings.h
@@ -8,6 +8,7 @@
 #define __APP_SETTINGS_H__
 
 int32_t get_loop_delay_s(void);
+uint16_t get_adc_floor(uint8_t ch_num);
 int app_register_settings(struct golioth_client *settings_client);
 
 #endif /* __APP_SETTINGS_H__ */

--- a/src/app_work.c
+++ b/src/app_work.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(app_work, LOG_LEVEL_DBG);
 
 #include "app_work.h"
 #include "app_state.h"
+#include "app_settings.h"
 #include <qcbor/qcbor.h>
 #include <qcbor/qcbor_decode.h>
 #include <qcbor/qcbor_spiffy_decode.h>
@@ -157,7 +158,7 @@ static int push_adc_to_golioth(uint16_t ch0_data, uint16_t ch1_data) {
 
 static int update_ontime(uint16_t adc_value, adc_node_t *ch) {
 	if (k_sem_take(&adc_data_sem, K_MSEC(300)) == 0) {
-		if (adc_value == 0) {
+		if (adc_value <= get_adc_floor(ch->ch_num)) {
 			ch->runtime = 0;
 			ch->laston = -1;
 		}


### PR DESCRIPTION
* Add ADC_FLOOR_CH0 and ADC_FLOOR_CH1 to settings service
* These settings hold raw ADC values. If the reading is equal to or smaller than this setting the device being monitored will be considered "off". This is an adjustment necessary for equipment that has a standby current draw.

Signed-off-by: Mike Szczys <mike@golioth.io>