### PR TITLE
release: v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - TBA
+## [1.0.0] - 2023-11-15
 
 ### Added
 - Initial release
 - Support for aludel_mini_v1_sparkfun9160 (custom Golioth board)
+- Support for nrf9160dk_nrf9160_ns (commercially available)


### PR DESCRIPTION
This commit represents the first feature-complete state of the Golioth AC Power Monitor Reference Design.

Track changes using CHANGELOG.md