### PR TITLE
workflows: fix artifact handling

### DIFF
--- a/.github/workflows/build_zephyr.yml
+++ b/.github/workflows/build_zephyr.yml
@@ -78,11 +78,9 @@ jobs:
         run: |
           cd build
           mkdir -p artifacts
-          BOARD_NICENAME=${{ inputs.BOARD }}
-          BOARD_NICENAME=${BOARD_NICENAME//\//_}
-          mv merged.hex                   ./artifacts/ac_power_monitor_${{ inputs.TAG }}_${BOARD_NICENAME}_full.hex
-          mv app/zephyr/zephyr.signed.bin ./artifacts/ac_power_monitor_${{ inputs.TAG }}_${BOARD_NICENAME}_update.bin
-          mv app/zephyr/zephyr.elf        ./artifacts/ac_power_monitor_${{ inputs.TAG }}_${BOARD_NICENAME}.elf
+          mv merged.hex                   ./artifacts/ac_power_monitor_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_full.hex
+          mv app/zephyr/zephyr.signed.bin ./artifacts/ac_power_monitor_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}_update.bin
+          mv app/zephyr/zephyr.elf        ./artifacts/ac_power_monitor_${{ inputs.TAG }}_${{ steps.nicename.outputs.BOARD_NICENAME }}.elf
 
       # Run IDs are unique per repo but are reused on re-runs
       - name: Save artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
             version:
                 description: 'Release Version.'
                 required: true
-                default: 'template_v0.0.0'
+                default: 'v0.0.0'
                 type: string
 
 jobs:
@@ -40,7 +40,7 @@ jobs:
               with:
                 pattern: build_artifacts_*
                 path: ~/artifacts
-                merge_multiple: true
+                merge-multiple: true
 
             - name: Create Release manually with GH CLI
               run: gh release create --title ${{ inputs.version }} --draft ${{ inputs.version }}


### PR DESCRIPTION
- Correct how uploaded artifacts are named during the build
- Fix artifact-download property that had underscore instead of dash
- Update release workflow to use tag without "template_" prefix